### PR TITLE
Fixed a basic typo

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -16,7 +16,7 @@ function App() {
   const [data, setData] = useState({
     data: {
       name: 'Lit Protocol',
-      description: 'Threadshold cryptography for the win!',
+      description: 'Threshold cryptography for the win!',
     }
   });
 


### PR DESCRIPTION
Simple typo:

"Threadshold cryptography" -> "Threshold cryptography".